### PR TITLE
Add dpkg-packages directory feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,16 @@ Example:
 ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true
 ```
 
+## dpkg-packages
+Optional directory holding `.deb` packages to be installed automatically
+after `apt-packages`, `apt-repositories` and `apt-debconf`. Allows the
+installation of custom packages inside the container.
+
+Example:
+
+```
+$ ls dpkg-packages/
+your-package-0_0.0.1.deb
+```
 
 [dokku]: https://github.com/progrium/dokku

--- a/pre-build
+++ b/pre-build
@@ -24,6 +24,12 @@ if [ -f $DIR/apt-packages ]; then
     apt-get install -y \$PACKAGES
     echo "-----> Injected packages: \$PACKAGES"
 fi
+if [ -d $DIR/dpkg-packages ]; then
+    for pkg in $DIR/dpkg-packages/*.deb; do
+        dpkg -i \$pkg
+        echo "-----> Injected package: \$pkg"
+    done
+fi
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF
 )


### PR DESCRIPTION
dpkg-packages/ is an optional directory holding .deb packages which will
be automatically installed in the final stage of the plugin's pre-build
hook. It allows for arbitrary or custom packages to be installed inside
the container.