### PR TITLE
added plugin.toml for dokku 0.4.0 plugn compatibility

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+name = "dokku-apt"
+description = "Inject deb packages into dokku based on files in project"
+version = "0.1.0"
+website_url = "https://github.com/expa/dokku-apt"
+[plugin.config]


### PR DESCRIPTION
This PR adds dokku 0.4.0 support by adding a plugin.toml file.