### PR TITLE
forgive trailing line breaks

### DIFF
--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -13,12 +13,16 @@ if [ -f $DIR/apt-repositories ]; then
     apt-get update
     apt-get install -y software-properties-common apt-transport-https
     cat "$DIR/apt-repositories" | while read repository; do
-        add-apt-repository -y "\$repository"
+        if [ -n "$repository" ]; then
+            add-apt-repository -y "\$repository"
+        fi
     done
 fi
 if [ -f $DIR/apt-debconf ]; then
     cat "$DIR/apt-debconf" | while read conf; do
-        echo \$conf | debconf-set-selections
+        if [ -n "$conf" ]; then
+            echo \$conf | debconf-set-selections
+        fi
     done
 fi
 if [ -f $DIR/apt-packages ]; then


### PR DESCRIPTION
Closes [#16](https://github.com/F4-Group/dokku-apt/issues/16)

When there is a trailing line break in the file 

```
> cat -e apt-repositories 
ppa:ubuntu-toolchain-r/test$
$
```

indicated by the trailing `$` when viewing with `cat -e`, we attempt to download an empty string `''` causing `add-apt-repository` to throw `Error: '' invalid`, which kills the script and subsequently the deployment

While this is technically user error, we can make it a bit more user friendly at no real cost